### PR TITLE
LFP timefreq analysis functions

### DIFF
--- a/DefineStates.m
+++ b/DefineStates.m
@@ -1,0 +1,51 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% DefineStates.m 
+% Script which defines information about states in a struct
+% Define all states to be analysed
+% state_ID: state identifier (integer) - required
+% state_name: name of the state - required
+% state_desc: description of the state
+% tminus_onset: time in seconds before the state onset where LFP analysis
+% should start (for future use)
+% tplus_onset: time in seconds up to which the LFP analysis should be done
+% from the state onset (for future use)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+clear;
+
+all_states = struct();
+
+% Trial start
+% all_states(1).state_ID = 1;
+% all_states(1).state_name = 'trial_ini';
+% all_states(1).state_desc = 'Initialization of a trial';
+% all_states(1).tminus_onset = 0; % time to be considered for analysis before state onset
+% all_states(1).tplus_onset = 0.5; % time to be considered for analysis after state onset
+% 
+% % Fixation acq
+% all_states(2).state_ID = 2;
+% all_states(2).state_name = 'fix_acq';
+% all_states(2).state_desc = 'Fixation acquisition';
+
+% % Fixation hold
+% all_states(3).state_ID = 3;
+% all_states(3).state_name = 'fix_hold';
+% all_states(3).state_desc = 'Fixation hold';
+% 
+
+% Cue onset
+all_states(1).state_ID = 6;
+all_states(1).state_name = 'cue_on';
+all_states(1).state_desc = 'Cue onset';
+all_states(1).tminus_onset = 0.4; % time to be considered for analysis before state onset
+all_states(1).tplus_onset = 0.6; % time to be considered for analysis after state onset
+
+% Reach start
+all_states(2).state_ID = 62;
+all_states(2).state_name = 'reach_start';
+all_states(2).state_desc = 'Reach start';
+all_states(2).tminus_onset = 0.4; % time to be considered for analysis before state onset
+all_states(2).tplus_onset = 0.6; % time to be considered for analysis after state onset
+
+save all_states;

--- a/computeAndPlotTFR.m
+++ b/computeAndPlotTFR.m
@@ -1,0 +1,314 @@
+function [ ft_data_sites, TFR_avg ] = computeAndPlotTFR( ft_data_sites, baseline ) 
+%, choice, inactivation, analyse_states, all_states )
+%UNTITLED5 Summary of this function goes here
+%   Detailed explanation goes here
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % This script takes the data structure with site wise and trial wise 
+    % arranged LFP data and creates a data structure which is compatible with 
+    % the FT_DATATYPE_RAW for time frequency analysis of LFP
+    % The data structure will be arranged as follows:
+    % Sites -> Site (site ID, site name, states) -> State (state name,
+    % handspace) -> handspace (label, trial (LFP), time)
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    %close all;
+    % folder to save figures
+    fig_folder = 'C:\Data\MIP_timefreq_analysis\Figures\';
+    
+    
+    sessionName = ft_data_sites(1).session;
+    fig_folder_tfr = fullfile(fig_folder, sessionName, date, 'handspace_LFP_timefreq_analysis');
+    mkdir(fig_folder_tfr);
+    
+
+    % define the states to be analysed, should have same name as defined in
+    % all_states data structure
+    analyse_states = {ft_data_sites(1).states.name};
+    % hand-space tuning of LFP
+    hs_label = {ft_data_sites(1).states(1).hndspc.label};
+    
+%     % whether to consider choice trial or instructed for analysis (0 =
+%     % instructed only, 2 = choice only, else both)
+%     choice = 0;
+%     % whether to choose control or inactivation trials
+%     % 1 = only control trials, 0 = only inactivation trials
+%     control = 0; 
+
+    % cell array to store time frequency average across sites
+    TFR_avg = cell(length(analyse_states),length(hs_label));
+    
+    % loop through each site
+    nsites = length(ft_data_sites);
+
+%     % create a data structure for time-freq analysis per site
+%     ft_data_sites = struct();
+% 
+
+    
+    %ft_data_allsites.nsites = ft_data_allsites.nsites + nsites;
+%     for i = 1:length(session_lfp)
+%         site = session_lfp(i);
+%         ft_data_sites(i).session = site.session;
+%         ft_data_sites(i).target = site.target;
+%         ft_data_sites(i).siteID = site.site_ID;
+%         ft_data_sites(i).states = struct();
+%         ft_data_sites(i).TFR_hs = cell(length(analyse_states),length(hs_label));
+%         for st = 1:length(analyse_states)
+%             % store name of the state
+%             ft_data_sites(i).states(st).name = analyse_states(st);%all_states([all_states.state_ID] == analyse_states{st}).state_name;
+%             % struct to save hand-space tuned FT type LFP data for this state
+%             ft_data_sites(i).states(st).hndspc = struct();
+%             % initialize hand-space tuning structures
+%             for hs = 1:length( hs_label)
+%                 ft_data_sites(i).states(st).hndspc(hs).label = hs_label(hs);
+%                 ft_data_sites(i).states(st).hndspc(hs).trial = {};
+%                 ft_data_sites(i).states(st).hndspc(hs).time  = {};
+%             end
+%         end
+%         % loop through each trial for this site
+%         blocks = [];
+%         ntrials = 0;
+%         for t = 1:length(site.trials)
+%             trial = site.trials(t);
+%             % whether this trial should be considered
+%             consider_trial = ~trial.noisy; % if trial is not noisy 
+%             % consider a trial based on whether it is instructed or choice
+%             % trial
+%             if choice == 1 % user wants to select choice trials
+%                 consider_trial = consider_trial && trial.choice_trial; % depending on whether trial is instructed or not
+%             else % user wants to select instructed trials
+%                 consider_trial = consider_trial && trial.choice_trial == 0;
+%             end
+%             % consider a trial based on whether it is control or
+%             % inactivation trial
+% %             if inactivation == 1 % user wants to select inactivation trials
+% %                 consider_trial = consider_trial && trial.perturbation; 
+% %             else
+% %                 consider_trial = consider_trial && trial.perturbation == 0; 
+% %             end
+%             % if trial should be considered
+%             if consider_trial%~trial.noisy && ~trial.choice_trial && 
+%                 ntrials = ntrials + 1;
+%                 blocks = [blocks, trial.block];
+%                 hs_tuning = trial.hndspc_lbl;
+%                 hs_idx = find(strcmp(hs_label, hs_tuning));
+% 
+%                 % loop through states
+%                 for st = 1:length(trial.states)
+%                     state = trial.states(st);
+%                     st_idx = find(strcmp(analyse_states, state.name));
+%                     ft_data_sites(i).states(st_idx).hndspc(hs_idx).trial = ...
+%                         [ft_data_sites(i).states(st_idx).hndspc(hs_idx).trial; ...
+%                         trial.lfp_data(state.start_s:state.end_s)];
+%                     ft_data_sites(i).states(st_idx).hndspc(hs_idx).time = ...
+%                         [ft_data_sites(i).states(st_idx).hndspc(hs_idx).time; ...
+%                         trial.time(state.start_s:state.end_s) - trial.time(state.onset_s)];
+%                     ft_data_sites(i).states(st_idx).hndspc(hs_idx).fsample = trial.fsample;
+%                 end            
+%             end
+%         end
+%         ft_data_sites(i).nblocks = length(unique(blocks));
+%         ft_data_sites(i).ntrials = ntrials;
+        
+        % per-site time frequency analysis
+        % make a folder for saving figures
+        mkdir(fig_folder);
+        
+    for i = 1:length(ft_data_sites)
+        figure; colormap jet;%
+        % make a struct for concatenating TFR for all states
+        concat_states_TFR = struct();
+        % loop through each hand-space tuning
+        for hs = 1:length(hs_label)
+            % baseline for this handspace tuning
+            data_lfp_baseline = ft_data_sites(i).baseline.hndspc(hs);
+            % configuration for TFR of baseline
+            if ~isempty(data_lfp_baseline.trial)
+                nsample = length(data_lfp_baseline.time{1});
+                fs = data_lfp_baseline.fsample;
+                ts = 1/fs;
+                tstart = data_lfp_baseline.time{1}(1);
+                tend = data_lfp_baseline.time{1}(end);
+                cfg              = [];
+                cfg.output       = 'pow';
+                cfg.method       = 'mtmconvol';
+                cfg.taper        = 'hanning';
+                cfg.pad          = 'nextpow2';
+                cfg.foi          = fs/500:fs/500:fs/10;             % analysis 2 to 100 Hz in steps of 2 Hz
+                cfg.t_ftimwin    = ones(length(cfg.foi),1).*200*ts;    % length of time window = 0.2 sec
+                cfg.toi          = linspace(tstart, tend, nsample);% time window "slides" from -0.5 to 1.5 sec in steps of 0.05 sec (50 ms)
+                cfg.channel      = data_lfp_baseline.label;
+                disp(['Processing ' cfg.channel]);
+                TFR_baseline     = ft_freqanalysis(cfg, data_lfp_baseline);
+                % get mean value of baseline power for each frequency
+                baseline_mean = nanmean(TFR_baseline.powspctrm, 3);
+            end
+            % loop through each state
+            for st = 1:length(ft_data_sites(i).states)
+                % now this is a FT_DATATYPE_RAW on which FT time frequency
+                % analzsis can be done
+                data_lfp_st_hs = ft_data_sites(i).states(st).hndspc(hs);
+                nsample = length(ft_data_sites(i).states(st).hndspc(hs).time{1});
+                if ~isempty(data_lfp_st_hs.trial)
+                    fs = data_lfp_st_hs.fsample;
+                    ts = 1/fs;
+                    tstart = data_lfp_st_hs.time{1}(1);
+                    tend = data_lfp_st_hs.time{1}(end);
+                    % configuration for TFR
+                    cfg              = [];
+                    cfg.output       = 'pow';
+                    cfg.method       = 'mtmconvol';
+                    cfg.taper        = 'hanning';
+                    cfg.pad          = 'nextpow2';
+                    cfg.foi          = fs/500:fs/500:fs/10;             % analysis 2 to 100 Hz in steps of 2 Hz
+                    cfg.t_ftimwin    = ones(length(cfg.foi),1).*200*ts;    % length of time window = 0.2 sec
+                    cfg.toi          = linspace(tstart, tend, nsample);% time window "slides" from -0.5 to 1.5 sec in steps of 0.05 sec (50 ms)
+                    cfg.channel      = data_lfp_st_hs.label;
+                    disp(['Processing ' cfg.channel]);
+                    TFRhann_fixed = ft_freqanalysis(cfg, data_lfp_st_hs);    
+                    % subtract baseline mean for each frequency
+                    TFRhann_fixed.powspctrm = TFRhann_fixed.powspctrm - ...
+                        repmat(baseline_mean, [1 1 size(TFRhann_fixed.powspctrm, 3)]);
+                    % concatenate TFRs for each state
+                    if st == 1
+                        concat_states_TFR = TFRhann_fixed;
+                    else
+                        % concatenate times
+                        % add an arbitrary large number for concatenated trials
+                        concat_states_TFR.time = [concat_states_TFR.time, TFRhann_fixed.time];
+                        concat_states_TFR.powspctrm = cat(3, concat_states_TFR.powspctrm, TFRhann_fixed.powspctrm);
+                    end
+
+                    % now save the TFR to corresponding hand space tuning
+                    ft_data_sites(i).TFR{st, hs} = TFRhann_fixed;
+
+                    % accumulate TFR per site for averaging across sites
+                    if i == 1
+                        TFR_avg{st, hs} = TFRhann_fixed;
+                        TFR_avg{st, hs}.powspctrm = (1/nsites) * TFRhann_fixed.powspctrm;
+                        TFR_avg{st, hs}.ntrials = length(data_lfp_st_hs.trial);
+                    else
+                        TFR_avg{st, hs}.powspctrm = TFR_avg{st, hs}.powspctrm + (1/nsites) * TFRhann_fixed.powspctrm;
+                        TFR_avg{st, hs}.ntrials = TFR_avg{st, hs}.ntrials + length(data_lfp_st_hs.trial);
+                    end
+                    TFR_avg{st, hs}.label = strcat(analyse_states(st),hs_label(hs));
+                else
+                    ft_data_sites(i).TFR{st, hs} = [];
+                end
+            
+            end 
+
+            % Visualization
+            if ~isempty(concat_states_TFR) > 0
+                % normalize power spectrogram by z-score
+%                 concat_states_TFR.powspctrm = (concat_states_TFR.powspctrm - ...
+%                     nanmean(concat_states_TFR.powspctrm(:))) / nanstd(concat_states_TFR.powspctrm(:));
+                time_to_event = concat_states_TFR.time;
+                tshift = time_to_event(1);
+                % first rearrange the time axis of TFR
+                bin_t = concat_states_TFR.time(2) - concat_states_TFR.time(1);
+                concat_states_TFR.time = 0:bin_t:bin_t*(length(concat_states_TFR.time)-1);
+                % now find the state onsets in the new time axis
+                rearr_state_onset_t = concat_states_TFR.time(time_to_event == 0);
+                %600*ts%0:1:length(concat_states_TFR.time)-1;
+                % rearrange the baseline
+                baseline = [-0.4 -0.1];
+                baseline_shift = baseline - tshift;
+
+                cfg = [];
+                cfg.baseline     = 'no'; %baseline_shift;                 % -400ms to -100ms before the onset of first state
+                cfg.baselinetype = 'absolute';  
+                cfg.maskstyle    = 'saturation';
+                cfg.zlim         = [-1.5e-9 1.5e-9];
+                cfg.masknans     = 'yes';
+                cfg.channel  = concat_states_TFR.label;
+                subplot(2,2,hs)
+                ft_singleplotTFR(cfg, concat_states_TFR);
+                % mark state onsets
+                set(gca,'xtick',rearr_state_onset_t)
+                set(gca,'xticklabels',strrep(analyse_states, '_', '\_'))
+                for t = rearr_state_onset_t
+                    line([t t], ylim);
+                end
+                xlabel('Time');
+                ylabel('Frequency');
+                title(sprintf('%s (ntrials = %g)', cfg.channel{1}, length(data_lfp_st_hs.trial)));
+                line([0 0], ylim, 'color', 'k');
+            end
+        end
+        % plot title
+    %     sgtitle(sprintf('Session: %s, Target = %s, Site: %s (nblocks = %g)', ft_data_sites(i).session, ...
+    %         ft_data_sites(i).target, ft_data_sites(i).siteID, ft_data_sites(i).nblocks));
+        plottitle = ['Session: ' ft_data_sites(i).session ', Target = ' ft_data_sites(i).target ', Site ID: ' ft_data_sites(i).siteID ...
+            '(nblocks = ' num2str(ft_data_sites(i).nblocks) ')'];
+        ann = annotation('textbox', [0 0.9 1 0.1], 'String', strrep(plottitle, '_', '\_')...
+            , 'EdgeColor', 'none', 'HorizontalAlignment', 'center');
+        saveas(gca, fullfile(fig_folder_tfr, [ft_data_sites(i).siteID '.png']));
+    end
+
+    % save variables
+    save ft_data_sites ft_data_sites;
+    %save TFR_avg TFR_avg;
+
+    %%% Visualiyation of time frequency average across site %%%
+    figure; colormap jet;
+    for hs = 1:length(hs_label)
+        for st = 1:length(analyse_states)
+            % first concatenate TFR for different states for one hs tuning for
+            % visualization
+            if st == 1
+                concat_TFR_avg = TFR_avg{st,hs};
+                concat_TFR_avg.label = hs_label{hs};
+            else
+                concat_TFR_avg.time = [concat_TFR_avg.time TFR_avg{st,hs}.time];
+                concat_TFR_avg.powspctrm = cat(3, concat_TFR_avg.powspctrm, TFR_avg{st,hs}.powspctrm);
+            end
+
+        end
+
+        % Visualization
+
+        time_to_event = concat_TFR_avg.time;
+        tshift = time_to_event(1);
+        % first rearrange the time axis of TFR
+        bin_t = concat_TFR_avg.time(2) - concat_TFR_avg.time(1);
+        concat_TFR_avg.time = 0:bin_t:bin_t*(length(concat_TFR_avg.time)-1);
+        % now find the state onsets in the new time axis
+        rearr_state_onset_t = concat_TFR_avg.time(time_to_event == 0);
+        % rearrange the baseline
+        baseline = [-0.4 -0.1];
+        baseline_shift = baseline - tshift;
+
+        cfg = [];
+        cfg.baseline     = 'no';%baseline_shift;                 % -400ms to -100ms before the state onset
+        cfg.baselinetype = 'absolute';  
+        cfg.maskstyle    = 'saturation';
+        cfg.zlim         = [-1.5e-9 1.5e-9];
+        cfg.masknans     = 'yes';
+        %concat_TFR_avg.label = TFR_avg{st,hs}.label{1};
+        cfg.channel  = concat_TFR_avg.label;
+        subplot(2,2,hs)
+        ft_singleplotTFR(cfg, concat_TFR_avg);
+        % mark state onsets
+        set(gca,'xtick',rearr_state_onset_t)
+        set(gca,'xticklabels',strrep(analyse_states, '_', '\_'))
+        for t = rearr_state_onset_t
+            line([t t], ylim);
+        end
+        xlabel('Time');
+        ylabel('Frequency');
+        title(sprintf('%s', cfg.channel{1}));
+        line([0 0], ylim, 'color', 'k');
+    end
+
+    % plot title
+    plottitle = ['Session: ' ft_data_sites(i).session '(nsites = ', ...
+        num2str(length(ft_data_sites)), 'nblocks = ' num2str(ft_data_sites(i).nblocks) ')'];
+    ann = annotation('textbox', [0 0.9 1 0.1], 'String', strrep(plottitle, '_', '\_')...
+        , 'EdgeColor', 'none', 'HorizontalAlignment', 'center');
+    % sgtitle(sprintf('Session: %s, Target = %s, (nsites = %g)', ft_data_sites(1).session, ...
+    %     ft_data_sites(1).target(1:end-2), length(ft_data_sites)));
+    saveas(gca, fullfile(fig_folder_tfr, [ft_data_sites(1).session '.png']));
+
+end
+

--- a/evokedLFPAnalysis.m
+++ b/evokedLFPAnalysis.m
@@ -1,0 +1,128 @@
+function [ evoked_lfp ] = evokedLFPAnalysis( ft_data_sites )
+%UNTITLED6 Summary of this function goes here
+%   Detailed explanation goes here
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % Evoked LFP Analysis Script
+    % This script calculates the mean and standard deviation of LFP data from
+    % all trials per site and also average across sites
+    % This script takes the structure created in Prepare_FT_Datastruct_persite
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %close all;
+    % create a struct to store evoked LFP analysis results
+    evoked_lfp = struct();
+
+    % folder to save figures
+    fig_folder = 'C:\Data\MIP_timefreq_analysis\Figures\';
+    
+    
+    sessionName = ft_data_sites(1).session;
+    fig_folder_evoked = fullfile(fig_folder, sessionName, date, 'LFP_evoked_analysis');
+    mkdir(fig_folder_evoked);
+
+
+    % cell array to store handspace tuned lfp data of all sites
+    grand_lfp_arr = cell(1,length([ft_data_sites(1).states(1).hndspc.label]));
+    % loop through each site
+    for i = 1:length(ft_data_sites)
+        figure; % to plot mean and std of LFP for each site
+        % get site info
+        evoked_lfp(i).siteID = ft_data_sites(i).siteID;
+        evoked_lfp(i).target = ft_data_sites(i).target;
+        evoked_lfp(i).session = ft_data_sites(i).session;
+        evoked_lfp(i).nblocks = ft_data_sites(i).nblocks;
+        % loop through each handspace label
+        hs_labels = [ft_data_sites(1).states(1).hndspc.label];
+        for hs = 1:length(hs_labels)
+            evoked_lfp(i).label(hs).name = hs_labels(hs);
+            % loop through each state
+            analyse_states = {ft_data_sites(1).states  .name};
+            lfp_arr = [];
+            lfp_time = [];
+            state_start_s = zeros(1,length(analyse_states)); % start sample of each state
+            state_end_s = zeros(1,length(analyse_states)); % end sample of each state
+            for st = 1:length(analyse_states)
+                evoked_lfp(i).label(hs).state(st).name = analyse_states(st);
+                state_start_s(st) = size(lfp_arr, 2);
+                % concatenate all states
+                lfp_arr = [lfp_arr cell2mat(ft_data_sites(i).states(st).hndspc(hs).trial)];
+                lfp_time = [lfp_time ft_data_sites(i).states(st).hndspc(hs).time{1}];
+                state_end_s(st) = size(lfp_arr, 2);
+            end
+            % accumulate sites
+            grand_lfp_arr{hs} = [grand_lfp_arr{hs}; lfp_arr];
+            state_onset_s = find(lfp_time == 0);
+            evoked_lfp(i).label(hs).ntrials = size(lfp_arr, 1);
+            % save state info in evoked LFP struct
+            evoked_lfp(i).label(hs).state(st).start_s = state_start_s(st);
+            evoked_lfp(i).label(hs).state(st).onset_s = state_onset_s(st);
+            evoked_lfp(i).label(hs).state(st).end_s = state_end_s(st);
+            % find mean and standard deviation
+            lfp_mean = mean(lfp_arr, 1);
+            evoked_lfp(i).label(hs).lfp_mean = lfp_mean;
+            % plot mean
+            subplot(2,2,hs)
+            plot(lfp_mean)
+
+            std_lfp = std(lfp_arr, 1);
+            evoked_lfp(i).label(hs).std_LFP = std_lfp;
+            % plot std
+            hold on; plot(lfp_mean + std_lfp, 'r', 'linestyle', '--');
+            plot(lfp_mean - std_lfp, 'r', 'linestyle', '--');
+
+            % mark states
+            for st = 1:length(analyse_states)
+                line([state_onset_s(st) state_onset_s(st)], ylim, 'color', 'k');
+                line([state_end_s(st) state_end_s(st)], ylim, 'color', 'k', 'linewidth',3);
+                line([state_onset_s(st) state_onset_s(st)], ylim, 'color', 'k');
+                line([state_end_s(st) state_end_s(st)], ylim, 'color', 'k', 'linewidth',3);
+                % mark state onsets
+                set(gca,'xtick',state_onset_s)
+                set(gca,'xticklabels',strrep(analyse_states, '_', '\_'))
+            end  
+            title(hs_labels(hs));
+        end
+        plottitle = ['Session: ' evoked_lfp(i).session ', Target = ' evoked_lfp(i).target ', Site ID: ' evoked_lfp(i).siteID ...
+            '(nblocks = ' num2str(evoked_lfp(i).nblocks) ')'];
+        ann = annotation('textbox', [0 0.9 1 0.1], 'String', strrep(plottitle, '_', '\_')...
+            , 'EdgeColor', 'None', 'HorizontalAlignment', 'center');
+        saveas (gca, fullfile(fig_folder_evoked, [evoked_lfp(i).siteID '_evoked_LFP.png']))
+    end
+    save evoked_LFP_analysis evoked_lfp;
+
+    % Average across sites
+    nblocks = 0;
+    nsites = numel(evoked_lfp);
+    for site = evoked_lfp
+        nblocks = site.nblocks + nblocks;
+    end
+    figure;
+    for hs = 1:length(site.label)
+        lfp_mean = mean(grand_lfp_arr{hs}, 1);
+        lfp_std = std(grand_lfp_arr{hs}, 1);
+        % plot
+        % plot mean
+        subplot(2,2,hs)
+        plot(lfp_mean)
+
+        % plot std
+        hold on; plot(lfp_mean + std_lfp, 'r', 'linestyle', '--');
+        plot(lfp_mean - lfp_std, 'r', 'linestyle', '--');
+
+        % mark states
+        for st = 1:length(analyse_states)
+            line([state_onset_s(st) state_onset_s(st)], ylim, 'color', 'k');
+            line([state_end_s(st) state_end_s(st)], ylim, 'color', 'k', 'linewidth',3);
+            line([state_onset_s(st) state_onset_s(st)], ylim, 'color', 'k');
+            line([state_end_s(st) state_end_s(st)], ylim, 'color', 'k', 'linewidth',3);
+            % mark state onsets
+            set(gca,'xtick',state_onset_s)
+            set(gca,'xticklabels',strrep(analyse_states, '_', '\_'))
+        end  
+        title(hs_labels(hs));
+    end  
+    plottitle = ['Session: ' evoked_lfp(1).session ' (nsites = ' num2str(nsites) ', nblocks = ' num2str(evoked_lfp(1).nblocks) ')'];
+    ann = annotation('textbox', [0 0.9 1 0.1], 'String', strrep(plottitle, '_', '\_')...
+        , 'EdgeColor', 'None', 'HorizontalAlignment', 'center');
+    saveas (gca, fullfile(fig_folder_evoked, [evoked_lfp(i).session '_evoked_LFP.png']))
+end
+

--- a/freqBaseLineNorm.m
+++ b/freqBaseLineNorm.m
@@ -1,0 +1,11 @@
+function powspctrm_norm = freqBaseLineNorm(ft_TFR, baseline, method)
+    powspctrm = ft_TFR.powspctrm;    
+    sq_powspctrm = squeeze(ft_TFR.powspctrm);
+    powspctrm_norm = zeros(size(powspctrm));
+    % find mean power for each freq bin during baseline period
+    powspctrm_baseline = sq_powspctrm(:,ft_TFR.time >= baseline(1) & ft_TFR.time <= baseline(2));
+    mean_pow_baseline = nanmean(powspctrm_baseline, 2);
+    for f = 1:length(ft_TFR.freq)
+        powspctrm_norm(1,f,:) = sq_powspctrm(f,:) - mean_pow_baseline(f);
+    end
+end

--- a/plotLFPPowerSpectrum.m
+++ b/plotLFPPowerSpectrum.m
@@ -1,0 +1,110 @@
+function [ lfp_spectrum ] = plotLFPPowerSpectrum( ft_data_sites )
+%UNTITLED6 Summary of this function goes here
+%   Detailed explanation goes here
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % plotLFPPowerSpectrum.m plots power spectrum for LFP per site and
+    % average acorss sites for 4 conditions
+    % This script calculates the mean and standard deviation of LFP data from
+    % all trials per site and also average across sites
+    % This script takes the structure created in Prepare_FT_Datastruct_persite
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    lfp_spectrum = struct();
+
+    % folder to save figures
+    fig_folder = 'C:\Data\MIP_timefreq_analysis\Figures\';
+    
+    
+    sessionName = ft_data_sites(1).session;
+    fig_folder_psd = fullfile(fig_folder, sessionName, date, 'LFP_powerspectrum');
+    mkdir(fig_folder_psd);
+
+    % cell array to store handspace tuned lfp data of all sites
+    %session_lfp_spectrum = cell(1,length([ft_data_sites(1).states(1).hndspc.label]));
+    % loop through each site
+    for i = 1:length(ft_data_sites)
+        figure; % to plot mean and std of LFP for each site
+        % get site info
+        lfp_spectrum(i).siteID = ft_data_sites(i).siteID;
+        lfp_spectrum(i).target = ft_data_sites(i).target;
+        lfp_spectrum(i).session = ft_data_sites(i).session;
+        lfp_spectrum(i).nblocks = ft_data_sites(i).nblocks;
+        % loop through each handspace label
+        hs_labels = [ft_data_sites(1).states(1).hndspc.label];
+        for hs = 1:length(hs_labels)
+            lfp_spectrum(i).label(hs).name = hs_labels(hs);
+            % loop through each state
+            analyse_states = {ft_data_sites(1).states  .name};
+            lfp_arr = [];
+            lfp_time = [];
+            state_end_s = zeros(1,length(analyse_states)); % end sample of each state
+            for st = 1:length(analyse_states)
+                lfp_spectrum(i).label(hs).state(st).name = analyse_states(st);
+                % concatenate all trials
+                lfp_arr = [lfp_arr cell2mat(ft_data_sites(i).states(st).hndspc(hs).trial)];
+                lfp_time = [lfp_time ft_data_sites(i).states(st).hndspc(hs).time{1}];
+                lfp_fs = ft_data_sites(i).states(st).hndspc(hs).fsample;
+                state_end_s(st) = size(lfp_arr, 2);
+            end
+            % accumulate sites
+            % grand_lfp_arr{hs} = [grand_lfp_arr{hs}; lfp_arr];
+            lfp_spectrum(i).label(hs).ntrials = size(lfp_arr, 1);
+            % array to store mean spectrum for each condition
+            lfp_spectrum(i).label(hs).mean_spectrum = zeros(1, size(lfp_arr, 2)/2 + 1);
+            % find mean lfp spectrum across all trials
+            for t = 1:size(lfp_arr, 1)
+                [psd, f] = powerspectrum(lfp_arr(t,:), lfp_fs);
+                lfp_spectrum(i).label(hs).mean_spectrum = ...
+                    lfp_spectrum(i).label(hs).mean_spectrum + psd;
+            end
+            lfp_spectrum(i).label(hs).mean_spectrum = ...
+                lfp_spectrum(i).label(hs).mean_spectrum / lfp_spectrum(i).label(hs).ntrials;
+            lfp_spectrum(i).label(hs).frequency = f;
+            
+            % plot mean power spectrum
+            subplot(2,2,hs)
+            plot((lfp_spectrum(i).label(hs).frequency), ...
+                10*log10(lfp_spectrum(i).label(hs).mean_spectrum));
+            xlabel('Frequency (Hz)');
+            ylabel('Power (dB)');
+            set(gca, 'XScale', 'log')
+            set(gca, 'xlim', [1e-1, 1e3]);
+            
+            grid on;
+
+            title(hs_labels(hs));
+        end
+        plottitle = ['Session: ' lfp_spectrum(i).session ', Target = ' lfp_spectrum(i).target ', Site ID: ' lfp_spectrum(i).siteID ...
+            '(nblocks = ' num2str(lfp_spectrum(i).nblocks) ')'];
+        ann = annotation('textbox', [0 0.9 1 0.1], 'String', strrep(plottitle, '_', '\_')...
+            , 'EdgeColor', 'None', 'HorizontalAlignment', 'center');
+        saveas (gca, fullfile(fig_folder, [lfp_spectrum(i).siteID '_spectrum.png']))
+    end
+    save lfp_spectrum lfp_spectrum;
+
+    % Average across sites
+    figure;
+    for site = lfp_spectrum
+        for hs = 1:length(site.label)
+            session_mean_psd = mean(site.label(hs).mean_spectrum, 1);
+            frequency = site.label(hs).frequency;
+            % plot
+            % plot mean
+            subplot(2,2,hs)
+            plot((frequency), 10*log10(session_mean_psd));
+            xlabel ('Frequency (Hz)');
+            ylabel ('Power (dB)');
+            set(gca, 'XScale', 'log')
+            set(gca, 'xlim', [1e-1, 1e3]);
+            
+            grid on;
+            
+            title(hs_labels(hs));
+        end  
+    end
+    plottitle = ['Session: ' lfp_spectrum(1).session ' (nsites = ' num2str(length(lfp_spectrum)) ', nblocks = ' num2str(lfp_spectrum(1).nblocks) ')'];
+    ann = annotation('textbox', [0 0.9 1 0.1], 'String', strrep(plottitle, '_', '\_')...
+        , 'EdgeColor', 'None', 'HorizontalAlignment', 'center');
+    saveas (gca, fullfile(fig_folder_psd, [lfp_spectrum(i).session '_spectrum.png']))
+end
+

--- a/powerspectrum.m
+++ b/powerspectrum.m
@@ -1,0 +1,8 @@
+function [psdx, freq] = powerspectrum(x, Fs)
+    N = length(x);
+    xdft = fft(x);
+    xdft = xdft(1:N/2+1);
+    psdx = (1/(Fs*N)) * abs(xdft).^2;
+    psdx(2:end-1) = 2*psdx(2:end-1);
+    freq = 0:Fs/length(x):Fs/2;
+end

--- a/prepareFTdatatype.m
+++ b/prepareFTdatatype.m
@@ -1,0 +1,262 @@
+function [ ft_data_sites, session_lfp ] = prepareFTdatatype( sites, analyse_states, ...
+    all_states, maxsites, choice, inactivation, baseline )
+%UNTITLED3 Summary of this function goes here
+%   Detailed explanation goes here
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % PrepareLFPDataPerSite.m
+    % Script to read in the sitewise LFP data and store the required
+    % information into a new struct sites_lfp. 
+    % Struct members:
+    % session: name of session
+    % site_ID: site identifier
+    % ipsilateral: ipsilateral hand for this site
+    % ipsilesional: ipsilesional hand for this site (for future use)
+    % trial: (1xM) struct to store information about trials recorded from the site
+    % 
+    %       block: block/run number
+    %       choice_trial: 0 (instructed), 2 (choice trial with 2 targets)
+    %       reach_hand: hand used to reach the target
+    %       reach_space: space in which target which is reached appeared
+    %       lfp_data: lfp data recorded for this trial (1xN)
+    %       time: timestamps of lfp data (1xN)
+    %       fsample: sampling freq of LFP data
+    %       tsample: sampling time of LFP data
+    %       hndspc_lbl: hand-space tuning for the trial
+    %       states: (1xK) struct which stores the information about states to
+    %       be analysed
+    %               name: name of the state (as defined in DefineStates.m_
+    %               onset_t: state onset time
+    %               onset_s: sample number of state onset
+    %               start_s: sample at which LFP analysis should start
+    %               end_s: sample at which LFP analysis should end
+    %               
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    
+    close all; 
+    
+    % prepare a root data structure for all sites
+    session_lfp = struct();
+
+    % Read in LFP data for the session
+    fprintf('Reading processed LFP data');
+    %load(session_filename);
+
+    % save data inside struct 
+    % first loop through each site
+    for i = 1:min(length(sites), maxsites)
+        session_lfp(i).session = sites(i).site_ID(1:end-8);
+        session_lfp(i).site_ID = sites(i).site_ID;
+        session_lfp(i).target = sites(i).target;
+        session_lfp(i).ipsilateral = session_lfp(i).target(end);
+        % create a ft_datatype_raw struct for storing LFP data for all trials
+        % see ft_rawdatatype
+        % sites_lfp(i).lfp_data = struct();
+        % now loop through each trial for this site
+        comp_trial = 0; % iterator for completed trials
+        for t = 1:length(sites(i).trial)
+            success = sites(i).trial(t).success;
+            noisy = sites(i).trial(t).noisy;
+            if success && ~noisy
+                comp_trial = comp_trial + 1;
+                block = sites(i).trial(t).block;
+                choice_trial = sites(i).trial(t).choice;
+                reach_hand = sites(i).trial(t).reach_hand; % 1 = left, 2 = right
+                perturbation = sites(i).trial(t).perturbation; % 0 = control
+                
+                % falg indicating whether this trial should be considered
+                % or not based on whether instructed or choice, control or
+                % inactivation
+                consider_trial = true;
+                % select choice or instructed trials based on user
+                % selection
+                if ~isnan(choice)
+                    if choice % user wants to select choice trials
+                        consider_trial = consider_trial & choice_trial ~= 0;
+                    else
+                        consider_trial = consider_trial & choice_trial == 0;
+                    end
+                end
+                % select choice or instructed trials based on user
+                % selection
+%                 if inactivation % user wants to select inactivat trials
+%                     consider_trial = consider_trial & perturbation ~= 0;
+%                 else
+%                     consider_trial = consider_trial & perturbation == 0;
+%                 end
+                if ~consider_trial
+                    comp_trial = comp_trial - 1;
+                    continue;
+                end
+                
+                % check if the trials have all the states to be analysed
+                trial_states = sites(i).trial(t).states;
+                
+                if ~all(ismember([analyse_states{:}], trial_states)) 
+                    comp_trial = comp_trial - 1;
+                    continue
+                end                    
+                
+                if reach_hand == 1, reach_hand = 'L'; else reach_hand = 'R'; end
+                tar_pos = sites(i).trial(t).tar_pos;
+                fix_pos = sites(i).trial(t).fix_pos;
+                if sign(real(tar_pos) - real(fix_pos)) == -1
+                    reach_space = 'L'; 
+                else
+                    reach_space = 'R';
+                end
+                % assign hand-space
+                if session_lfp(i).ipsilateral == reach_hand  
+                    if session_lfp(i).ipsilateral == reach_space
+                        hs_label = 'IH IS';
+                    else
+                        hs_label = 'IH CS';
+                    end
+                else 
+                    if session_lfp(i).ipsilateral == reach_space
+                        hs_label = 'CH IS';
+                    else
+                        hs_label = 'CH CS';
+                    end
+                end
+
+                %states = trial(i).states;
+                start_time = (sites(i).trial(t).TDT_LFPx_tStart); % trial start time
+                fs = sites(i).trial(t).TDT_LFPx_SR; % sample rate
+                LFP = sites(i).trial(t).LFP; % LFP data
+                ts = (1/fs); % sample time
+                nsamples = numel(LFP);
+                end_time = start_time + (ts*(nsamples-1));
+                timestamps = linspace(start_time, end_time, nsamples);
+
+                % save retrieved data into struct
+                session_lfp(i).trials(comp_trial).block = block;
+                session_lfp(i).trials(comp_trial).choice_trial = choice_trial;
+                session_lfp(i).trials(comp_trial).lfp_data = LFP;
+                session_lfp(i).trials(comp_trial).time = timestamps;
+                session_lfp(i).trials(comp_trial).fsample  = fs;
+                session_lfp(i).trials(comp_trial).tsample = ts;
+                session_lfp(i).trials(comp_trial).reach_hand  = reach_hand;
+                session_lfp(i).trials(comp_trial).reach_space  = reach_space;
+                session_lfp(i).trials(comp_trial).hndspc_lbl  = hs_label;
+                session_lfp(i).trials(comp_trial).perturbation  = perturbation;
+
+
+    %             % get movement onset time
+    %             reach_start = sites(i).trial(t).states_onset(sites(i).trial(t).states == 62);
+    %             % give cue_onset zero timestamp 
+    %             reach_start_sample = find(abs(timestamps - reach_start) == min(abs(timestamps - reach_start)));
+
+                
+                % get state onset times and onset samples
+                session_lfp(i).trials(comp_trial).states = struct();
+                for s = 1:length(analyse_states)
+                    % get state onset time
+                    state_onset = sites(i).trial(t).states_onset(sites(i).trial(t).states == all_states(s).state_ID);
+                    % get sample number of state onset time
+                    state_onset_sample = find(abs(timestamps - state_onset) == min(abs(timestamps - state_onset)));
+                    % save into struct
+                    session_lfp(i).trials(comp_trial).states(s).name  = all_states(s).state_name;
+                    session_lfp(i).trials(comp_trial).states(s).onset_t  = state_onset;
+                    session_lfp(i).trials(comp_trial).states(s).onset_s  = state_onset_sample;
+                    session_lfp(i).trials(comp_trial).states(s).start_s  = max(1, state_onset_sample - 400);
+                    session_lfp(i).trials(comp_trial).states(s).end_s = min(length(timestamps), state_onset_sample + 600);
+                end
+                
+                % define baseline
+                session_lfp(i).trials(comp_trial).baseline = struct();
+                baseline_ref_s = session_lfp(i).trials(comp_trial).states(...
+                    strcmp({session_lfp(i).trials(comp_trial).states.name}, ...
+                    baseline.ref_state)).onset_s;
+                session_lfp(i).trials(comp_trial).baseline.ref_s = ...
+                    baseline_ref_s;
+                session_lfp(i).trials(comp_trial).baseline.start_s = ...
+                    baseline_ref_s + sample(baseline.period(1), 0, ts);
+                session_lfp(i).trials(comp_trial).baseline.end_s = ...
+                    baseline_ref_s + sample(baseline.period(2), 0, ts);
+
+                
+            end
+        end
+    end
+        
+    %sites_lfp(i).lfp_data.fsample = fs;
+    ft_data_sites = struct();
+    for i = 1:length(session_lfp)
+        site = session_lfp(i);
+        ft_data_sites(i).session = site.session;
+        ft_data_sites(i).target = site.target;
+        ft_data_sites(i).siteID = site.site_ID;
+        ft_data_sites(i).ipsilateral = site.ipsilateral;
+        ft_data_sites(i).states = struct();
+        hs_labels = unique({session_lfp(i).trials.hndspc_lbl});
+        ft_data_sites(i).TFR_hs = cell(length(analyse_states),length(hs_labels));
+        for st = 1:length(analyse_states) % add 1 for baseline
+            % store name of the state
+            ft_data_sites(i).states(st).name = all_states([all_states.state_ID] == analyse_states{st}).state_name;
+            % struct to save hand-space tuned FT type LFP data for this state
+            ft_data_sites(i).states(st).hndspc = struct();
+            % initialize hand-space tuning structures
+            for hs = 1:length( hs_labels)
+                ft_data_sites(i).states(st).hndspc(hs).label = hs_labels(hs);
+                ft_data_sites(i).states(st).hndspc(hs).trial = {};
+                ft_data_sites(i).states(st).hndspc(hs).time  = {};
+            end
+        end
+        % initialize struct to store baseline
+        ft_data_sites(i).baseline = struct();
+        % struct to save hand-space tuned FT type LFP data for this state
+        ft_data_sites(i).baseline.hndspc = struct();
+        % initialize hand-space tuning structures
+        for hs = 1:length( hs_labels)
+            ft_data_sites(i).baseline.hndspc(hs).label = hs_labels(hs);
+            ft_data_sites(i).baseline.hndspc(hs).trial = {};
+            ft_data_sites(i).baseline.hndspc(hs).time  = {};
+            ft_data_sites(i).baseline.hndspc(hs).sampleinfo = [];
+        end
+        % loop through each trial for this site
+        blocks = [];
+        ntrials = 0;
+        for t = 1:length(site.trials)
+            trial = site.trials(t);
+            
+            ntrials = ntrials + 1;
+            blocks = [blocks, trial.block];
+            hs_tuning = trial.hndspc_lbl;
+            hs_idx = find(strcmp(hs_labels, hs_tuning));
+
+            % loop through states
+            for st = 1:length(trial.states)
+                state = trial.states(st);
+                st_idx = find(strcmp({ft_data_sites(i).states.name}, state.name));
+                %ft_data_sites(i).states(st_idx).hndspc(hs_idx).label = hs_tuning;
+                ft_data_sites(i).states(st_idx).hndspc(hs_idx).trial = [ft_data_sites(i).states(st_idx).hndspc(hs_idx).trial; ...
+                    trial.lfp_data(state.start_s:state.end_s)];
+                ft_data_sites(i).states(st_idx).hndspc(hs_idx).time = [ft_data_sites(i).states(st_idx).hndspc(hs_idx).time; ...
+                    trial.time(state.start_s:state.end_s) - trial.time(state.onset_s)];
+                ft_data_sites(i).states(st_idx).hndspc(hs_idx).fsample = trial.fsample;
+            end   
+            
+            % baseline
+            baseline = trial.baseline;
+            
+            %st_idx = length(ft_data_sites(i).states)+1;
+            %ft_data_sites(i).states(st_idx).name = 'baseline';
+            ft_data_sites(i).baseline.hndspc(hs_idx).label = {hs_tuning};
+            ft_data_sites(i).baseline.hndspc(hs_idx).trial = [ft_data_sites(i).baseline.hndspc(hs_idx).trial; ...
+                trial.lfp_data(baseline.start_s:baseline.end_s)];
+            ft_data_sites(i).baseline.hndspc(hs_idx).time = [ft_data_sites(i).baseline.hndspc(hs_idx).time; ...
+                trial.time(baseline.start_s:baseline.end_s) - trial.time(baseline.ref_s)];
+            ft_data_sites(i).baseline.hndspc(hs_idx).fsample = trial.fsample;
+            
+        end
+        ft_data_sites(i).nblocks = length(unique(blocks));
+        ft_data_sites(i).ntrials = ntrials;
+        
+    end
+
+    % save data
+    save session_lfp session_lfp;
+    save ft_data_sites ft_data_sites;
+
+end
+

--- a/rejectNoisyLFP.m
+++ b/rejectNoisyLFP.m
@@ -1,0 +1,401 @@
+function [sites, noisy_lfp_trials] = rejectNoisyLFP( sites, cfg_nr )
+%UNTITLED4 Summary of this function goes here
+%   Detailed explanation goes here
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % RejectNoisyTrials.m
+    % Script to reject noisy trials
+    % Method 1: A trial is rejected if 10 consecutive LFP samples are beyond 0.001 and
+    % 99.999 percentile of all LFP samples across all trials from a site
+    % Method 2: A trial is rejected LFP standard deviation for a trial is
+    % greater than 2*std of LFP samples across all trials from a site
+    % Method 3: A trial is rejected if 10 consecutive LFP samples are beyond 0.1 and
+    % 99.9 percentile of all LFP samples across all trials from a site
+    % Method 4: A trial is rejected if in the TFR at any time bin, more than
+    % half of the frequency bins have a power larger than mean + 2*std of LFP
+    % power over all trials 
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    %clear;
+    close all;
+    %fig_folder = 'C:\Data\MIP_timefreq_analysis\Figures\';
+    
+    %sessionName = sites(1).site_ID(1:end-8);
+    %fig_folder_noise = fullfile(fig_folder, sessionName, date, 'LFP_Noise_Rejection');
+    %mkdir(fig_folder_noise);
+    
+    % which method(s) to use for noise rejection
+    %methods = [3];
+    % if configuration is missing assign default configuration
+    if isempty(cfg_nr) % empty configuration structure
+        % create a configuration structurewith default values
+        cfg_nr = struct();
+        % methods to be used
+        cfg_nr.methods = {'amp', 'std', 'diff'};
+        % threshold for lfp raw amplitude
+        cfg_nr.amp_thr = [0.001 99.999];
+        % number of consecutive samples beyond threshold to be considered
+        cfg_nr.amp_N = 10;
+        % no of standard deviations of trial w.r.t complete LFP std
+        cfg_nr.std_thr = 4;
+        % threshold for lfp derivative in percentile
+        cfg_nr.diff_thr = [0.1 99.9];
+        % number of consecutive samples beyond threshold to be considered
+        cfg_nr.diff_N = 10;
+    end        
+    
+    % struct to store information about noisy lfps
+    noisy_lfp_trials = struct();
+
+    % read in lfp data for each site
+    for i = 1:length(sites)
+        site = sites(i);
+        noisy_lfp_trials(i).site = site.site_ID;
+        % cell arrays to store LFP raw data, derivative, blocks and LFP power for all trials
+        concat_site_lfp = cell(1,length(site.trial));
+        concat_site_diff_lfp = cell(1,length(site.trial)); % store derivative of LFP for each trial
+        concat_blocks = zeros(1, length(site.trial));
+        concat_site_lfp_pow = cell(1,length(site.trial));
+        %concat_site_lfp_pow = cell(1,length(site.trial));
+        % read lfp data for each trial
+        for t = 1:length(site.trial)
+            % create a new field to indicate if the trial is noisy
+            sites(i).trial(t).noisy = 0;
+            trial = site.trial(t);
+            if trial.success
+                block = trial.block;
+                lfp_data = trial.LFP;
+                fs = trial.TDT_LFPx_SR;
+                ts = 1/fs;
+                timestamps = linspace(0, ts*(length(lfp_data)), length(lfp_data));
+                
+    %             % structure to store state specific time and lfp
+    %             state_time_lfp = [];
+    %             for state = trial.states
+    %                 state_time_lfp = [state_time_lfp; [timestamps(state.start_s:state.end_s); ...
+    %                     lfp_data(state.start_s:state.end_s)]'];
+    %                 %trial_lfp = [trial_lfp state_lfp(:,2)']; 
+    %             end
+    %             % get data with unique timestamps
+    %             unq_state_time_lfp  = unique(state_time_lfp, 'rows');
+    %             trial_lfp = unq_state_time_lfp(:,2)';
+    %             timestamps = unq_state_time_lfp(:,1)';
+
+
+                % save lfp for this trial into cell array
+                concat_site_lfp{t} = lfp_data;
+                concat_site_diff_lfp{t} = [nan diff(lfp_data)]; 
+                concat_blocks(t) = block;
+                    
+                % calculate the TFR if method 'pow' is active
+                if sum(strcmp(cfg_nr.methods, 'pow'))
+                    
+                    % per site time frequency analysis using FT for noise rejection
+                    ft_lfp_data             = struct();
+                    ft_lfp_data.trial       = {lfp_data};
+                    ft_lfp_data.time        = {0:ts:ts*(length(lfp_data)-1)};
+                    ft_lfp_data.fsample     = fs;
+                    ft_lfp_data.sampleinfo  = [0 ts*(length(lfp_data)-1)];
+                    ft_lfp_data.label       = {site.site_ID};
+
+                    % configuration for TFR
+                    cfg              = [];
+                    cfg.output       = 'pow';
+                    cfg.method       = 'mtmconvol';
+                    cfg.taper        = 'hanning';
+                    cfg.pad          = 'nextpow2';
+                    cfg.foi          = 2:2:100;             % analysis 2 to 100 Hz in steps of 2 Hz
+                    cfg.t_ftimwin    = ones(length(cfg.foi),1).*500*ts;    % length of time window = 0.5 sec
+                    cfg.toi          = 0:50*ts:ts*(length(lfp_data)-1);% time window "slides" from -0.5 to 1.5 sec in steps of 0.05 sec (50 ms)
+                    cfg.channel      = ft_lfp_data.label;
+                    TFR_hann_fixed   = ft_freqanalysis(cfg, ft_lfp_data);
+
+                    % subtract the baseline from spectrogram
+                    % get the baseline period
+                    baseline_ref_t = trial.states_onset(trial.states == cfg_nr.pow_refstate); % cue
+                    baseline_period = [baseline_ref_t + cfg_nr.pow_baseline(1)...
+                        baseline_ref_t + cfg_nr.pow_baseline(2)];
+                    TFR_hann_fixed.powspctrm = freqBaseLineNorm(TFR_hann_fixed, baseline_period, 'absolute');
+                    concat_site_lfp_pow{t} = TFR_hann_fixed.powspctrm;
+                    
+                end
+            end
+        end
+        % concatenate all datapoints to a 1d array
+        arr_concat_site_lfp = horzcat(concat_site_lfp{:});
+        % now get the 0.10 and 99.9 percentile of LFP for each site
+        site_lfp_min = prctile(arr_concat_site_lfp, cfg_nr.amp_thr(1));
+        site_lfp_max = prctile(arr_concat_site_lfp, cfg_nr.amp_thr(2));
+%         site_lfp_mean = mean(arr_concat_site_lfp);
+        % standard deviation of lfp values for this site
+        site_lfp_std = std(arr_concat_site_lfp);
+        % save this data into the struct
+%         session_lfp(i).lfp_mean = site_lfp_mean;
+%         session_lfp(i).lfp_std = site_lfp_std;  
+        
+        % concatenate all derivatives to a 1d array
+        arr_concat_diff_lfp = horzcat(concat_site_diff_lfp{:});
+        % get the 0.1 and 99.9 percentile of derivative for each site
+        lfp_diff_minbound = prctile(arr_concat_diff_lfp, cfg_nr.diff_thr(1));
+        lfp_diff_maxbound = prctile(arr_concat_diff_lfp, cfg_nr.diff_thr(2));
+        % now get the mean and std of LFP for each site
+        lfp_diff_mean = nanmean(arr_concat_diff_lfp);
+        lfp_diff_std = nanstd(arr_concat_diff_lfp);
+        % save this data into the struct
+%         session_lfp(i).lfp_diff_mean = lfp_diff_mean;
+%         session_lfp(i).lfp_diff_std = lfp_diff_std;  
+        
+%         % concatenate all power spectrums to a 3d array
+%         arr_concat_site_lfp_pow = vertcat(concat_site_lfp_pow{:});
+%         % now get the mean and std of LFP for each site
+%         site_lfp_pow_mean = mean(arr_concat_site_lfp_pow, 1);
+%         site_lfp_pow_std = std(arr_concat_site_lfp_pow, 1);
+%         TFR_avg = TFR_hann_fixed;
+%         TFR_avg.powspctrm = site_lfp_pow_mean;       
+%         
+        if sum(strcmp(cfg_nr.methods, 'pow'))
+            
+            % find the spectral power average
+            arr_concat_trials_tfr = cat(3,concat_site_lfp_pow{:});
+            pow_mean_f = nanmean(arr_concat_trials_tfr, 3);
+            pow_std_f = nanstd(arr_concat_trials_tfr, 0, 3);
+            
+        end
+        
+        % arrays to store noisy trials from each method separately
+        noisy_trials_lfp_mean = zeros(1,length(concat_site_lfp));
+        noisy_trials_lfp_std = zeros(1,length(concat_site_lfp));
+        noisy_trials_lfp_diff = zeros(1,length(concat_site_lfp));
+        noisy_trials_lfp_pow = zeros(1, length(concat_site_lfp));     
+        % now find the noisy trials 
+        % a trial is noisy if any LFP datapoint in the trial is beyond mean +/-
+        % 3std of the concatenated LFP for that site
+        % loop through each trial lfp again       
+    
+        for t = 1:length(site.trial)
+            if ~isempty(concat_site_lfp{t})
+                trial_lfp_std = std(concat_site_lfp{t});
+                n = 0; 
+                for d = concat_site_lfp{t}
+                    if d < site_lfp_min || d > site_lfp_max
+                        n = n + 1;
+                        if n >= cfg_nr.amp_N
+                            sites(i).trial(t).noisy = 1;
+                            noisy_trials_lfp_mean(t) = 1;
+                            break;
+                        end
+                    else
+                        n = 0;
+                    end
+                end
+%                 if sum((concat_site_lfp{t} > ones(1, length(concat_site_lfp{t})) * ...
+%                         (site_lfp_mean + 6*site_lfp_std)) + ...
+%                         (concat_site_lfp{t} < ones(1, length(concat_site_lfp{t})) * ...
+%                         (site_lfp_mean - 6*site_lfp_std)))
+%                     sites(i).trial(t).noisy = 1;
+%                     noisy_trials_lfp_mean(t) = 1;
+%                 end
+                % a trial is noisy if the LFP std of trial is beyond 2*std for the
+                % site
+                if trial_lfp_std > cfg_nr.std_thr*site_lfp_std
+                    sites(i).trial(t).noisy = 1;
+                    noisy_trials_lfp_std(t) = 1;
+                end            
+                % a trial is noisy if for more than maxN consecutive samples,
+                % derivative of LFP is greater or less than mean +/- 2*std of
+                % LFP derivative of all trials
+                maxN = 10; % maximum no of consecutive samples
+                N = 0; % counter
+                for d = concat_site_diff_lfp{t}
+                    if d > lfp_diff_maxbound || d < lfp_diff_minbound
+                        N = N + 1; % increment counter
+                        if N >= cfg_nr.diff_N
+                            sites(i).trial(t).noisy = 1;
+                            noisy_trials_lfp_diff(t) = 1; 
+                            break;
+                        end
+                    else % reset counter
+                        N = 0;
+                    end
+                end
+                
+                % a trial is noisy if at any time point the spectral power for
+                % more than 50% of freq bins is larger than mean power + 2*std 
+                % of all trials at that time bin
+                if sum(strcmp(cfg_nr.methods, 'pow'))
+                    for tbin = 1:size(concat_site_lfp_pow{t}, 3)
+                        pow_t = concat_site_lfp_pow{t}(:,:,tbin);
+                        noisyfbins = sum(pow_t > pow_mean_f + cfg_nr.pow_thr*pow_std_f);
+                        if noisyfbins / size(concat_site_lfp_pow{t}, 2) > 0.5
+                            sites(i).trial(t).noisy = 1;
+                            noisy_trials_lfp_pow(t) = 1;
+                            break;
+                        end
+                    end
+                end
+
+                % a trial is noisy if the spectral power for 50% of frequency bins at any time bin 
+                % is greater than mean power + 2*std of all trials at that time bin
+    %             for tbin = 1:size(concat_site_lfp_pow{t}, 3)
+    %                 pow_t = concat_site_lfp_pow{t}(:,:,tbin);
+    %                 noisyfbins = sum(pow_t > site_lfp_pow_mean(:,:,tbin) + ...
+    %                     2*site_lfp_pow_std(:,:,tbin));
+    %                 if noisyfbins / size(concat_site_lfp_pow{t}, 2) > 0.5
+    %                     sites(i).trial(t).noisy = 1;
+    %                     noisy_trials_lfp_mean(t) = 1;
+    %                     break;
+    %                 end
+    %             end
+                
+            end
+        end
+        
+        noisy_trials_all = noisy_trials_lfp_mean | noisy_trials_lfp_std | ...
+            noisy_trials_lfp_diff | noisy_trials_lfp_pow;
+        fprintf('Total number trials: %g \n', length(site.trial));
+        fprintf('No of rejected trials, lfp mean: %g \n', sum(noisy_trials_lfp_mean));
+        fprintf('No of rejected trials, std: %g \n', sum(noisy_trials_lfp_std));
+        fprintf('No of rejected trials, lfp diff: %g \n', sum(noisy_trials_lfp_diff));
+        fprintf('No of rejected trials, lfp power: %g \n', sum(noisy_trials_lfp_pow));
+        
+        % save into struct
+        noisy_lfp_trials(i).raw_amp = find(noisy_trials_lfp_mean);
+        noisy_lfp_trials(i).raw_std = find(noisy_trials_lfp_std);
+        noisy_lfp_trials(i).raw_diff = find(noisy_trials_lfp_diff);
+        noisy_lfp_trials(i).lfp_pow = find(noisy_trials_lfp_pow);
+        noisy_lfp_trials(i).all_noisy = find(noisy_trials_all);
+        %session_lfp(i).ntrails = length(site.trials);
+        %session_lfp(i).noisytrails = sum(noisy_trials_lfp_mean);
+        
+        % get blockwise statistics of noise rejected trials for printing
+        % and visualzation
+        unq_blocks = unique(concat_blocks);
+        % number samples in each block
+        block_nsamples = zeros(1, length(unq_blocks));
+        % no of trials in each block
+        block_ntrials = zeros(1, length(unq_blocks));
+        % no of rejected trials in each block
+        block_nrejtrials = zeros(1, length(unq_blocks));
+        
+        for b = 1:length(unq_blocks)
+            block_trials_lfp = horzcat(concat_site_lfp{concat_blocks == unq_blocks(b)}) ;
+            block_nsamples(b) = length(block_trials_lfp);
+%             for t = 1:length(site.trials)
+%                 block_nsamples(b) = block_nsamples(b)...
+%                     + length(concat_site_lfp{t});
+%             end
+            block_ntrials(b) = sum(concat_blocks == unq_blocks(b));
+            block_nrejtrials(b) = sum(concat_blocks == unq_blocks(b) & ...
+                noisy_trials_lfp_mean == 1);
+        end
+        
+        % plots
+        % plot the concatenated lfp for each site with mean and std
+        figure
+        hold on
+        nsubplots = length(cfg_nr.methods) - 1; % std method not plotted
+        subplot(nsubplots, 1, 1)
+        plot(arr_concat_site_lfp)
+        line(xlim, [site_lfp_min site_lfp_min], 'color', 'r');
+        line(xlim, [site_lfp_max site_lfp_max], 'color', 'r');
+        title(sprintf('Raw LFP, noisy trials = %g', sum(noisy_trials_lfp_mean)));
+        % divide blocks by drawing vertical lines
+        block_end_sample = 0;
+        for b = 1:length(unq_blocks)
+            
+            block_end_sample = block_end_sample + block_nsamples(b);
+            line([block_end_sample block_end_sample], ylim, 'color', 'k', ...
+                'linestyle', '--');
+            block_ann = ['Block ', unq_blocks(b), ' ntrials = ' num2str(block_ntrials(b)), ' nrejected = ' num2str(block_nrejtrials(b))];
+            %annotation('textbox', [1 0.6 0.1 0.3], 'String', block_ann);
+        end
+        subplot(nsubplots, 1, 2)
+        plot(arr_concat_diff_lfp)
+        line(xlim, [lfp_diff_minbound lfp_diff_minbound], 'color', 'g');
+        line(xlim, [lfp_diff_maxbound lfp_diff_maxbound], 'color', 'g');
+        title(sprintf('LFP derivative, noisy trials = %g', sum(noisy_trials_lfp_diff)));
+%         subplot(322)
+%         histfit(arr_concat_site_lfp);
+%         subplot(324)
+%         histfit(arr_concat_diff_lfp);
+        if sum(strcmp(cfg_nr.methods, 'pow'))
+            subplot(nsubplots, 1, 3)
+            % concatenate all noisy trials
+            arr_noisy_lfp_pow = cat(3, concat_site_lfp_pow{find(noisy_trials_lfp_pow)});
+            % make a tfr struct compatible with FT
+            noisy_tfr = TFR_hann_fixed;
+            noisy_tfr.powspctrm = arr_noisy_lfp_pow;
+            noisy_tfr.time = linspace(0, ts*length(arr_noisy_lfp_pow), length(arr_noisy_lfp_pow));
+            % plot TFR
+            cfg = [];
+            cfg.zlim         = [min(arr_noisy_lfp_pow) max(arr_noisy_lfp_pow)];
+            cfg.channel  = noisy_tfr.label;
+            ft_singleplotTFR(cfg, noisy_tfr);
+            title(sprintf('LFP power, noisy trials = %g', sum(noisy_trials_lfp_pow)));
+        end
+        %spectrogram(arr_concat_site_lfp, 100, 50, 100, 1e3, 'yaxis');
+        %line(xlim, [site_lfp_mean site_lfp_mean], 'color', 'k');
+        
+        %line(xlim, [lfp_diff_mean lfp_diff_mean], 'color', 'k');
+%         line(xlim, [lfp_diff_minbound lfp_diff_minbound], 'color', 'g');
+%         line(xlim, [lfp_diff_maxbound lfp_diff_maxbound], 'color', 'g');
+%         line(xlim, [site_lfp_mean site_lfp_mean], 'color', 'k');
+%         line(xlim, [site_lfp_mean + 6*site_lfp_std site_lfp_mean + 6*site_lfp_std], 'color', 'r');
+%         line(xlim, [site_lfp_mean - 6*site_lfp_std site_lfp_mean - 6*site_lfp_std], 'color', 'r');
+%         line(xlim, [lfp_diff_mean lfp_diff_mean], 'color', 'k');
+%         line(xlim, [lfp_diff_mean + 6*lfp_diff_std lfp_diff_mean + 6*lfp_diff_std], 'color', 'g');
+%         line(xlim, [site_lfp_mean - 6*lfp_diff_std lfp_diff_mean - 6*lfp_diff_std], 'color', 'g');
+        plottitle = ['Site = ', strrep(site.site_ID, '_', '\_'), '(ntrials = '...
+            num2str(length(site.trial)), ' ncompleted = ', num2str(sum([site.trial.success])) ...
+            ' naccepted = ', num2str(sum([site.trial.success]) - sum(noisy_trials_all)), ')']
+%             , length(site.trial), ...
+%             sum([site.trial.success]), sum([site.trial.success]) - sum(noisy_trials_lfp)]
+%         title(sprintf('Site = %s, (ntrials = %g, ncompleted = %g naccepted = %g)', ...
+%             strrep(site.site_ID, '_', '\_'), length(site.trial), ...
+%             sum([site.trial.success]), sum([site.trial.success]) - sum(noisy_trials_lfp)));
+        annotation('textbox', [0 0.9 1 0.1], 'String', plottitle, ...
+            'EdgeColor', 'none', 'HorizontalAlignment', 'center');
+        
+        %saveas(gca, fullfile(fig_folder_noise, [sites(i).site_ID '_concat_LFP.png']));
+        
+        % plot the concatenated lfp derivative for each site with mean and std
+%         figure
+%         hold on
+%         plot(arr_concat_diff_lfp)
+%         line(xlim, [lfp_diff_mean lfp_diff_mean], 'color', 'k');
+%         line(xlim, [lfp_diff_mean + 3*lfp_diff_std lfp_diff_mean + 3*lfp_diff_std], 'color', 'r');
+%         line(xlim, [site_lfp_mean - 3*lfp_diff_std lfp_diff_mean - 3*lfp_diff_std], 'color', 'r');
+%         title(sprintf('Site = %s, (ntrials = %g, naccepted = %g)', strrep(site.site_ID, '_', '\_'), t, length(site.trials) - session_lfp(i).noisytrails));
+%         % divide blocks by drawing vertical lines
+%         block_end_sample = 0;
+%         for b = 1:length(unq_blocks)
+%             
+%             block_end_sample = block_end_sample + block_nsamples(b);
+%             line([block_end_sample block_end_sample], ylim, 'color', 'k', ...
+%                 'linestyle', '--');
+%             block_ann = ['Block ', unq_blocks(b), ' ntrials = ' num2str(block_ntrials(b)), ' nrejected = ' num2str(block_nrejtrials(b))];
+%             %annotation('textbox', [1 0.6 0.1 0.3], 'String', block_ann);
+%         end
+%         saveas(gca, fullfile(fig_folder_noise, [session_lfp(i).site_ID '_concat_diff_LFP.png']));
+        
+        % plot the lfp TFR for each site with mean
+%         figure
+%         cfg = [];
+%         %cfg.baseline     = [-3e-27 3e-27];                 % -400ms to -100ms before the state onset
+%         cfg.baselinetype = 'no';%'absolute';  
+%         cfg.maskstyle    = 'saturation';
+%         cfg.zlim         = [-3e-10 3e-10];
+%         cfg.masknans     = 'yes';
+%         cfg.channel  = site.site_ID;
+%         ft_singleplotTFR(cfg, TFR_avg);
+%         xlabel('Time'), ylabel('Frequency');
+%         title(sprintf('Mean power (Site = %s, ntrials = %g)', strrep(site.site_ID, '_', '\_'), t));
+% 
+%         saveas(gca, fullfile(fig_folder_noise, [session_lfp(i).site_ID '_mean_pow.png']));
+        
+        
+    end
+    
+    %save sites sites;         
+
+end
+

--- a/sample.m
+++ b/sample.m
@@ -1,0 +1,7 @@
+function s = sample( t, t0, ts )
+%UNTITLED3 Summary of this function goes here
+%   Detailed explanation goes here
+    s = round((t - t0)/ts);
+
+end
+


### PR DESCRIPTION
1. DefineStates.m - Script to define information about states
2. LFP_timefreq_analysis.m - Script which defines the settings and calls other functions
3. rejectNoisyLFP.m - function to reject noisy LFP trials
4. prepareFTdatatype - function to read processed LFP structure sites_xxx_yyyymmdd.mat and prepare a fieldtrip type datastructure for TFR analysis
5. computeAndPlotTFR.m - function to compute spectrogram and plot
6. evokedLFPanalysis.m - function to compute evoked LFP
7. plotLFPPowerSpectrum.m - function to compute and plot spectral power of LFP
8. freqBaselineNorm.m - function to baseline normalize the power spectrogram 
9. sample.m - function to compute the current sample number given time of current sample, time of reference sample and sampling period ts.